### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rsdvops-tech-solutions/e04806a6-fd4d-43b3-b1f4-70780da5f244/2c871cbc-4463-4dba-9462-a0fa75c3bd11/_apis/work/boardbadge/f3617049-46d0-4173-b398-7773b021039f)](https://dev.azure.com/rsdvops-tech-solutions/e04806a6-fd4d-43b3-b1f4-70780da5f244/_boards/board/t/2c871cbc-4463-4dba-9462-a0fa75c3bd11/Microsoft.RequirementCategory)
 # <img align="center" height="70" src="./Docs/AppIcon.png"/> GitHub Copilot for Xcode
 
 <img alt="Demo of GitHub Copilot for Xcode" src="./Docs/demo.gif" width="800" />


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rsdvops-tech-solutions/e04806a6-fd4d-43b3-b1f4-70780da5f244/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.